### PR TITLE
#3 allow to customize the target for Next / Previous

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 
 Geert van Horrik <geert@catenalogic.com>
 Maksim Khomutov <mkhomutov@gmail.com>
+Patrick Näf <herzbube@herzbube.ch>

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Constants.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Constants.cs
@@ -12,5 +12,6 @@ namespace Orc.Wizard
     public static class WizardConfiguration
     {
         public static TimeSpan AnimationDuration = TimeSpan.FromMilliseconds(300);
+        public static readonly int CannotNavigate = -1;
     }
 }

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Models/Interfaces/IWizard.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Models/Interfaces/IWizard.cs
@@ -16,6 +16,7 @@ namespace Orc.Wizard
         #region Properties
         IWizardPage CurrentPage { get; }
         IEnumerable<IWizardPage> Pages { get; }
+        INavigationStrategy NavigationStrategy { get; }
         string Title { get; }
         bool CanResume { get; }
         bool CanCancel { get; }

--- a/src/Orc.Wizard/Orc.Wizard.Shared/NavigationStrategy/DefaultNavigationStrategy.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/NavigationStrategy/DefaultNavigationStrategy.cs
@@ -1,0 +1,87 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Constants.cs" company="WildGums">
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Orc.Wizard
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Catel;
+
+    public class DefaultNavigationStrategy : INavigationStrategy
+    {
+        #region Methods
+        public int GetIndexOfNextPage(IWizard wizard)
+        {
+            Argument.IsNotNull(() => wizard);
+
+            IEnumerable<IWizardPage> pages = wizard.Pages;
+            IWizardPage currentPage = wizard.CurrentPage;
+            if (currentPage == null)
+            {
+                IWizardPage firstPage = pages.FirstOrDefault();
+                if (firstPage == null)
+                {
+                    return WizardConfiguration.CannotNavigate;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else
+            {
+                IWizardPage lastPage = pages.LastOrDefault();
+                if (currentPage == lastPage)
+                {
+                    return WizardConfiguration.CannotNavigate;
+                }
+                else
+                {
+                    int indexOfCurrentPage = pages.ToList().IndexOf(currentPage);
+                    int indexOfNextPage = indexOfCurrentPage + 1;
+                    return indexOfNextPage;
+                }
+            }
+        }
+
+        public int GetIndexOfPreviousPage(IWizard wizard)
+        {
+            Argument.IsNotNull(() => wizard);
+
+            IEnumerable<IWizardPage> pages = wizard.Pages;
+            IWizardPage currentPage = wizard.CurrentPage;
+            if (currentPage == null)
+            {
+                IWizardPage lastPage = pages.LastOrDefault();
+                if (lastPage == null)
+                {
+                    return WizardConfiguration.CannotNavigate;
+                }
+                else
+                {
+                    int indexOfLastPage = pages.Count() - 1;
+                    return indexOfLastPage;
+                }
+            }
+            else
+            {
+                IWizardPage firstPage = pages.FirstOrDefault();
+                if (currentPage == firstPage)
+                {
+                    return WizardConfiguration.CannotNavigate;
+                }
+                else
+                {
+                    int indexOfCurrentPage = pages.ToList().IndexOf(currentPage);
+                    int indexOfPreviousPage = indexOfCurrentPage - 1;
+                    return indexOfPreviousPage;
+                }
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Orc.Wizard/Orc.Wizard.Shared/NavigationStrategy/Interfaces/INavigationStrategy.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/NavigationStrategy/Interfaces/INavigationStrategy.cs
@@ -1,0 +1,35 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Constants.cs" company="WildGums">
+//   Copyright (c) 2008 - 2016 WildGums. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Orc.Wizard
+{
+    /// <summary>
+    /// An INavigationStrategy object defines how forward and backward
+    /// navigation occurs within the wizard when the user clicks the "Next" or
+    /// the "Back" button. Providing a custom implementation of this interface
+    /// allows to customize the default behaviour of moving forward/backward
+    /// one page at a time.
+    /// </summary>
+    public interface INavigationStrategy
+    {
+        /// <summary>
+        /// Returns the index of the wizard page that should be displayed if
+        /// the user clicks the "Next" button. Returns
+        /// <em>Orc.Wizard.WizardConfiguration.CannotNavigate</em> to indicate
+        /// that navigating forward is not possible.
+        /// </summary>
+        int GetIndexOfNextPage(IWizard wizard);
+
+        /// <summary>
+        /// Returns the index of the wizard page that should be displayed if
+        /// the user clicks the "Back" button. Returns
+        /// <em>Orc.Wizard.WizardConfiguration.CannotNavigate</em> to indicate
+        /// that navigating backward is not possible.
+        /// </summary>
+        int GetIndexOfPreviousPage(IWizard wizard);
+    }
+}

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Orc.Wizard.Shared.projitems
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Orc.Wizard.Shared.projitems
@@ -35,6 +35,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\WizardBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\WizardPageBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModuleInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NavigationStrategy\Interfaces\INavigationStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NavigationStrategy\DefaultNavigationStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Extensions\IWizardServiceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\IWizardService.cs" />


### PR DESCRIPTION
To achieve the goal, an IWizard object must now be configured with an
INavigationStrategy object. WizardBase by default configures itself
with an DefaultNavigationStrategy object, which navigates sequentially
forward or backward through the currently configured wizard pages.
A concrete subclass of WizardBase can provide its own custom
implementation of INavigationStrategy to modify the default behaviour
(e.g. to skip one or more wizard pages based on the user's answers from
a previous page).