### PR TITLE
Allow Wizard window to be resizable and have a min/max size

### DIFF
--- a/src/Orc.Wizard/Orc.Wizard.Shared/Models/Interfaces/IWizard.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Models/Interfaces/IWizard.cs
@@ -18,6 +18,9 @@ namespace Orc.Wizard
         IEnumerable<IWizardPage> Pages { get; }
         INavigationStrategy NavigationStrategy { get; }
         string Title { get; }
+        System.Windows.ResizeMode ResizeMode { get; }
+        System.Windows.Size MinSize { get; }
+        System.Windows.Size MaxSize { get; }
         bool CanResume { get; }
         bool CanCancel { get; }
         bool CanMoveForward { get; }

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Models/WizardBase.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Models/WizardBase.cs
@@ -41,8 +41,8 @@ namespace Orc.Wizard
             _typeFactory = typeFactory;
 
             ResizeMode = System.Windows.ResizeMode.NoResize;
-            MinSize = new System.Windows.Size(650.0, 500.0);
-            MaxSize = new System.Windows.Size(650.0, 500.0);
+            MinSize = new System.Windows.Size(650d, 500d);
+            MaxSize = new System.Windows.Size(650d, 500d);
         }
 
         #region Properties

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Models/WizardBase.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Models/WizardBase.cs
@@ -39,6 +39,10 @@ namespace Orc.Wizard
             Argument.IsNotNull(() => typeFactory);
 
             _typeFactory = typeFactory;
+
+            ResizeMode = System.Windows.ResizeMode.NoResize;
+            MinSize = new System.Windows.Size(650.0, 500.0);
+            MaxSize = new System.Windows.Size(650.0, 500.0);
         }
 
         #region Properties
@@ -67,6 +71,12 @@ namespace Orc.Wizard
         }
 
         public string Title { get; protected set; }
+
+        public System.Windows.ResizeMode ResizeMode { get; protected set; }
+
+        public System.Windows.Size MinSize { get; protected set; }
+
+        public System.Windows.Size MaxSize { get; protected set; }
 
         public virtual bool CanResume
         {

--- a/src/Orc.Wizard/Orc.Wizard.Shared/ViewModels/WizardViewModel.cs
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/ViewModels/WizardViewModel.cs
@@ -45,6 +45,10 @@ namespace Orc.Wizard.ViewModels
         #region Properties
         [Model(SupportIEditableObject = false)]
         [Expose("CurrentPage")]
+        [Expose("ResizeMode")]
+        [Expose("MinSize")]
+        [Expose("MaxSize")]
+
         public IWizard Wizard { get; set; }
 
         public IEnumerable<IWizardPage> WizardPages { get; private set; } 

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Views/WizardWindow.xaml
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Views/WizardWindow.xaml
@@ -7,9 +7,14 @@
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                   xmlns:wizard="clr-namespace:Orc.Wizard"
                   xmlns:controls="clr-namespace:Orc.Wizard.Controls"
+                  ResizeMode="{Binding ResizeMode}"
+                  MinWidth="{Binding MinSize.Width}"
+                  MinHeight="{Binding MinSize.Height}"
+                  MaxWidth="{Binding MaxSize.Width}"
+                  MaxHeight="{Binding MaxSize.Height}"
                   mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300" Background="#F5F5F5">
 
-    <Grid x:Name="layoutRoot" Width="650" Height="500" Background="White">
+    <Grid x:Name="layoutRoot" Background="White">
         <Grid.RowDefinitions>
             <!-- First row is for InfoBarMessageControl -->
             <RowDefinition Height="Auto" />

--- a/src/Orc.Wizard/Orc.Wizard.Shared/Views/WizardWindow.xaml
+++ b/src/Orc.Wizard/Orc.Wizard.Shared/Views/WizardWindow.xaml
@@ -7,11 +7,11 @@
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                   xmlns:wizard="clr-namespace:Orc.Wizard"
                   xmlns:controls="clr-namespace:Orc.Wizard.Controls"
-                  ResizeMode="{Binding ResizeMode}"
-                  MinWidth="{Binding MinSize.Width}"
-                  MinHeight="{Binding MinSize.Height}"
-                  MaxWidth="{Binding MaxSize.Width}"
-                  MaxHeight="{Binding MaxSize.Height}"
+                  ResizeMode="{Binding ResizeMode, Mode=OneWay}"
+                  MinWidth="{Binding MinSize.Width, Mode=OneWay}"
+                  MinHeight="{Binding MinSize.Height, Mode=OneWay}"
+                  MaxWidth="{Binding MaxSize.Width, Mode=OneWay}"
+                  MaxHeight="{Binding MaxSize.Height, Mode=OneWay}"
                   mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300" Background="#F5F5F5">
 
     <Grid x:Name="layoutRoot" Background="White">


### PR DESCRIPTION
Previously the Wizard window was not resizable and had a hard-coded,
fixed size of 650 x 500. This commit introduces 3 new properties
(ResizeMode, MinSize, MaxSize) that allow a subclass of WizardBase to
make the Wizard window resizable and/or to set the window's minimum and
maximum size. This added flexibility is useful for wizard
implementations that consist of many pages or that contain pages that
require a larger client area.

The default behaviour of Orc.Wizard remains unchanged, i.e. the default
values for the 3 new properties are equal to the values previously
hard-coded into WizardWindow.xaml.

The above is the commit message. Here is a more technical explanation of the changes:

* I added three new properties on the `IWizard` interface and the `WizardBase` class
  * `ResizeMode`: Exposes the `ResizeMode` property of the WPF `System.Windows.Window` class
  * `MinSize`: Exposes the `MinWidth` and `MinHeight` properties of the WPF `System.Windows.Window` class
  * `MaxSize`: Exposes the `MaxWidth` and `MaxHeight` properties of the WPF `System.Windows.Window` class
* I followed the design of the already existing `Title` property
  * On the `IWizard` interface the new properties are read-only
  * On the `WizardBase` class the new properties are read-write, but the setter is protected only
* The `WizardViewModel` uses `Catel.Fody.ExposeAttribute` to pass the properties through from the model to the view
* The view (`WizardWindow.xaml`) now uses WPF bindings instead of hard-coding values
* The `WizardBase` constructor initializes the properties with default values that match the values previously hard-coded into `WizardWindow.xaml`
