### PR TITLE
Issue #503 Add auto sizing side navigation pane

### DIFF
--- a/src/Orc.Wizard.Example/ViewModels/MainViewModel.cs
+++ b/src/Orc.Wizard.Example/ViewModels/MainViewModel.cs
@@ -30,6 +30,7 @@
             HandleNavigationStates = true;
             MarkAllPagesAsVisited = false;
             CacheViews = true;
+            AutoSizeSideNavigationPane = false;
 
             Title = "Orc.Wizard example";
         }
@@ -50,6 +51,8 @@
         public bool MarkAllPagesAsVisited { get; set; }
 
         public bool CacheViews { get; set; }
+
+        public bool AutoSizeSideNavigationPane { get; set; }
         #endregion
 
         #region Commands
@@ -64,6 +67,7 @@
             wizard.AllowQuickNavigationWrapper = AllowQuickNavigation;
             wizard.HandleNavigationStatesWrapper = HandleNavigationStates;
             wizard.CacheViewsWrapper = CacheViews;
+            wizard.AutoSizeSideNavigationPaneWrapper = AutoSizeSideNavigationPane;  
 
             if (UseFastForwardNavigationController)
             {

--- a/src/Orc.Wizard.Example/Views/MainView.xaml
+++ b/src/Orc.Wizard.Example/Views/MainView.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -50,7 +51,9 @@
         <CheckBox Content="Handle navigation states" IsChecked="{Binding HandleNavigationStates}" />
         <CheckBox Content="Cache views (do not recreate on each page navigation)" IsChecked="{Binding CacheViews}" />
         <CheckBox Content="Mark all pages as visited before showing wizard" IsChecked="{Binding MarkAllPagesAsVisited}" />
-        
+        <CheckBox Content="Auto size side navigation pane" IsChecked="{Binding AutoSizeSideNavigationPane}" 
+                  ToolTip="Auto sizing adjusts the spacing between the ellipses in navigation pane so they fit without scrolling.  The spacing is calculated from the Wizard window minimum size (MinSize)."/>
+                          
         <StackPanel Orientation="Horizontal">
             <Button Command="{Binding ShowWizard}" 
                     CommandParameter="{x:Type local:ExampleWizard}"

--- a/src/Orc.Wizard.Example/Wizard/Models/ExampleFullScreenWizard.cs
+++ b/src/Orc.Wizard.Example/Wizard/Models/ExampleFullScreenWizard.cs
@@ -80,6 +80,12 @@ namespace Orc.Wizard.Example.Wizard
             set { CacheViews = value; }
         }
 
+        public bool AutoSizeSideNavigationPaneWrapper
+        {
+            get { return AutoSizeSideNavigationPane; }
+            set { AutoSizeSideNavigationPane = value; }
+        }
+
         public override Task ShowHelpAsync()
         {
             return _messageService.ShowAsync("HELP HANDLER");

--- a/src/Orc.Wizard.Example/Wizard/Models/ExampleSideNavigationWizard.cs
+++ b/src/Orc.Wizard.Example/Wizard/Models/ExampleSideNavigationWizard.cs
@@ -41,6 +41,8 @@ namespace Orc.Wizard.Example.Wizard
 
             MinSize = new System.Windows.Size(800, 600);
             MaxSize = new System.Windows.Size(1000, 800);
+            AutoSizeSideNavigationPane = true;
+
             ResizeMode = System.Windows.ResizeMode.CanResize;
         }
 
@@ -80,6 +82,12 @@ namespace Orc.Wizard.Example.Wizard
             set { CacheViews = value; }
         }
 
+        public bool AutoSizeSideNavigationPaneWrapper
+        {
+            get { return AutoSizeSideNavigationPane; }
+            set { AutoSizeSideNavigationPane = value; }
+        }
+
         public override Task ShowHelpAsync()
         {
             return _messageService.ShowAsync("HELP HANDLER");
@@ -90,6 +98,6 @@ namespace Orc.Wizard.Example.Wizard
             Log.Info("Resuming wizard");
 
             await base.ResumeAsync();
-        }
+        }       
     }
 }

--- a/src/Orc.Wizard.Example/Wizard/Models/ExampleWizard.cs
+++ b/src/Orc.Wizard.Example/Wizard/Models/ExampleWizard.cs
@@ -80,6 +80,12 @@ namespace Orc.Wizard.Example.Wizard
             set { CacheViews = value; }
         }
 
+        public bool AutoSizeSideNavigationPaneWrapper
+        {
+            get { return AutoSizeSideNavigationPane; }
+            set { AutoSizeSideNavigationPane = value; }            
+        }
+
         public override Task ShowHelpAsync()
         {
             return _messageService.ShowAsync("HELP HANDLER");

--- a/src/Orc.Wizard.Example/Wizard/Models/Interfaces/IExampleWizard.cs
+++ b/src/Orc.Wizard.Example/Wizard/Models/Interfaces/IExampleWizard.cs
@@ -15,5 +15,6 @@ namespace Orc.Wizard.Example.Wizard
         bool ShowHelpWrapper { get; set; }
         bool ShowInTaskbarWrapper { get; set; }
         bool CacheViewsWrapper { get; set; }
+        bool AutoSizeSideNavigationPaneWrapper { get; set; }
     }
 }

--- a/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml
+++ b/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml
@@ -71,7 +71,7 @@
         <Canvas HorizontalAlignment="Left" Margin="{x:Static controls:SideNavigationBreadcrumbItem.CanvasLineMargin}">
             <Rectangle x:Name="pathline" Width="2" Height="{Binding Path=NavigationItemLineLength}" StrokeThickness="0" 
                        Canvas.Left="{Binding ElementName=ellipse, Path=ActualWidth}"
-                       Canvas.Top="{Binding Path= NavigationItemLineTop}"
+                       Canvas.Top="{Binding Path=NavigationItemLineTop}"
                        HorizontalAlignment="Center" VerticalAlignment="Center" ClipToBounds="False"/>
         </Canvas>
     </Grid>

--- a/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml
+++ b/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml
@@ -7,7 +7,9 @@
              xmlns:converters="clr-namespace:Orc.Wizard.Converters"
              xmlns:xamlbehaviors="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:catel="http://schemas.catelproject.com"
-             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="400">
+             xmlns:controls="clr-namespace:Orc.Wizard.Controls"
+             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="400"
+             Loaded="UserControl_Loaded">
 
     <xamlbehaviors:Interaction.Triggers>
         <xamlbehaviors:EventTrigger EventName="MouseDown">
@@ -17,7 +19,7 @@
     </xamlbehaviors:Interaction.Triggers>
 
     <Grid DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type localcontrols:SideNavigationBreadcrumbItem}}}">
-        <Grid ToolTip="{Binding Description}" MinWidth="240" MaxWidth="240" Margin="0 0 0 56">
+        <Grid ToolTip="{Binding Description}" MinWidth="240" MaxWidth="240" Margin="{Binding NavigationItemMargin}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition/>
@@ -27,9 +29,13 @@
                 <RowDefinition/>
             </Grid.RowDefinitions>
 
-            <Grid Margin="15 5 25 5" Grid.Column="0">
-                <Ellipse x:Name="ellipse" Width="26" Height="26" StrokeThickness="0"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+            <Grid Margin="{x:Static controls:SideNavigationBreadcrumbItem.EllipseMargin}" Grid.Column="0">
+                <Ellipse x:Name="ellipse" 
+                         Width="{x:Static controls:SideNavigationBreadcrumbItem.EllipseDiameter}" 
+                         Height="{x:Static controls:SideNavigationBreadcrumbItem.EllipseDiameter}" 
+                         StrokeThickness="0"
+                         HorizontalAlignment="Center" 
+                         VerticalAlignment="Center" />
                 <TextBlock x:Name="ellipseText" Text="{Binding Number}" HorizontalAlignment="Center" 
                            Foreground="{DynamicResource Orc.Brushes.White}"
                            VerticalAlignment="Center" 
@@ -62,11 +68,10 @@
                        TextWrapping="Wrap"
                        Foreground="{DynamicResource Orc.Brushes.GrayBrush1}"/>
         </Grid>
-
-        <Canvas HorizontalAlignment="Left" Margin="2">
-            <Rectangle x:Name="pathline" Width="2" Height="48" StrokeThickness="0" 
+        <Canvas HorizontalAlignment="Left" Margin="{x:Static controls:SideNavigationBreadcrumbItem.CanvasLineMargin}">
+            <Rectangle x:Name="pathline" Width="2" Height="{Binding Path=NavigationItemLineLength}" StrokeThickness="0" 
                        Canvas.Left="{Binding ElementName=ellipse, Path=ActualWidth}"
-                       Canvas.Top="35"
+                       Canvas.Top="{Binding Path= NavigationItemLineTop}"
                        HorizontalAlignment="Center" VerticalAlignment="Center" ClipToBounds="False"/>
         </Canvas>
     </Grid>

--- a/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml.cs
+++ b/src/Orc.Wizard/Controls/SideNavigationBreadcrumbItem.xaml.cs
@@ -72,7 +72,7 @@
         }
 
         public static readonly DependencyProperty NavigationItemLineLengthProperty = DependencyProperty.Register(nameof(NavigationItemLineLength), typeof(int),
-            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(0));
+            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(NavigationItemLineLengthDefault));
 
         public int NavigationItemLineTop
         {
@@ -81,7 +81,7 @@
         }
 
         public static readonly DependencyProperty NavigationItemLineTopProperty = DependencyProperty.Register(nameof(NavigationItemLineTop), typeof(int),
-            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(0));
+            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(NavigationItemLineTopDefault));
 
         public Thickness NavigationItemMargin
         {
@@ -90,7 +90,7 @@
         }
 
         public static readonly DependencyProperty NavigationItemMarginProperty = DependencyProperty.Register(nameof(NavigationItemMargin), typeof(Thickness),
-            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(new Thickness()));
+            typeof(SideNavigationBreadcrumbItem), new PropertyMetadata(new Thickness(0, 0, 0, NavigationItemBottomMarginDefault)));
 
 
         private void OnPageChanged()
@@ -112,6 +112,13 @@
         public static Thickness CanvasLineMargin = new Thickness(2, 2, 2, 2);
         public static Thickness EllipseMargin = new Thickness(15, NavigationGridYMargin, 25, NavigationGridYMargin);
 
+        private const int NavigationItemLineLengthDefault = 48;
+        private const int NavigationItemBottomMarginDefault = 56;
+        private const int NavigationItemLineTopDefault = 35;
+
+        // This value is from SideNavigationWizardWindow.xaml
+        private const int ParentMarginTop = 12;
+
         private void AutoSizeNavigationPane()
 		{            
             // Determine the height required for the ellipse and its margins
@@ -120,8 +127,7 @@
             // Calculate the space required for all the navigation bubbles
             int totalSpaceNeeded = EllipseHeightAndMargin * Page.Wizard.Pages.Count(); 
                        
-            // This value is from SideNavigationWizardWindow.xaml
-            const int ParentMarginTop = 12;            
+            
             int TitleBarHeight = (int)SystemParameters.WindowCaptionHeight;
 
             // Using the Wizard Minimum Height calculate the extra vertical space
@@ -136,10 +142,10 @@
             int gridMargin = spaceLeftOver / (Page.Wizard.Pages.Count());
 
             // If the grid margin exceeds the default then...
-            if (gridMargin > 56)
+            if (gridMargin > NavigationItemBottomMarginDefault)
 			{
                 // Reset the grid margin back to the default
-                gridMargin = 56;
+                gridMargin = NavigationItemBottomMarginDefault;
             }
 
             // Determine the height of one bubble and the associated line
@@ -155,13 +161,13 @@
             SetCurrentValue(NavigationItemLineLengthProperty, navigationPaneHeight - (int)EllipseDiameter - 2 * LineMargin); 
             
             // If the line length exceeds the default then...
-            if (NavigationItemLineLength > 48)
+            if (NavigationItemLineLength > NavigationItemLineLengthDefault)
 			{
                 // Reset the line length back to the default
-                SetCurrentValue(NavigationItemLineLengthProperty, 48);
+                SetCurrentValue(NavigationItemLineLengthProperty, NavigationItemLineLengthDefault);
 
                 // Reset the start point back to the default
-                SetCurrentValue(NavigationItemLineTopProperty, 35);
+                SetCurrentValue(NavigationItemLineTopProperty, NavigationItemLineTopDefault);
             }
             else
 			{
@@ -225,13 +231,7 @@
             if (Page.Wizard.AutoSizeSideNavigationPane)
             {
                 AutoSizeNavigationPane();
-            }
-            else
-            {
-                SetCurrentValue(NavigationItemMarginProperty, new Thickness(0, 0, 0, 56));
-                SetCurrentValue(NavigationItemLineLengthProperty, 48);
-                SetCurrentValue(NavigationItemLineTopProperty, 35);
-            }
+            }           
         }
 	}
 }

--- a/src/Orc.Wizard/Models/Interfaces/IWizard.cs
+++ b/src/Orc.Wizard/Models/Interfaces/IWizard.cs
@@ -36,7 +36,6 @@ namespace Orc.Wizard
         bool CanShowHelp { get; }
         bool ShowInTaskbar { get; }
         bool AllowQuickNavigation { get; }
-
         bool AutoSizeSideNavigationPane { get; set; }
         #endregion
 

--- a/src/Orc.Wizard/Models/Interfaces/IWizard.cs
+++ b/src/Orc.Wizard/Models/Interfaces/IWizard.cs
@@ -36,6 +36,8 @@ namespace Orc.Wizard
         bool CanShowHelp { get; }
         bool ShowInTaskbar { get; }
         bool AllowQuickNavigation { get; }
+
+        bool AutoSizeSideNavigationPane { get; set; }
         #endregion
 
         Task CancelAsync();

--- a/src/Orc.Wizard/Models/WizardBase.cs
+++ b/src/Orc.Wizard/Models/WizardBase.cs
@@ -54,6 +54,7 @@ namespace Orc.Wizard
             CanShowHelp = true;
             HandleNavigationStates = true;
             AllowQuickNavigation = false;
+            AutoSizeSideNavigationPane = false;
         }
 
         #region Properties
@@ -169,6 +170,9 @@ namespace Orc.Wizard
         public bool ShowInTaskbar { get; protected set; }
 
         public bool AllowQuickNavigation { get; protected set; }
+
+        public bool AutoSizeSideNavigationPane { get; set; }
+
         #endregion
 
         #region Events


### PR DESCRIPTION
Issue #503 Add auto sizing side navigation pane

### Description of Change ###
I added a flag to IWizard to turn on auto size logic for the side navigation pane.  If the size of the window can accommodate the default spacing will be used.  If the size of the window is too small to use the default sizing the logic kicks in to calculate the size of the line and the spacing of the ellipses.   I tried to avoid changing the XAML design. 

### Issues Resolved ### 
fixes #503

### API Changes ###
Modified IWizard with a new flag AutoSizeSideNavigationPane.  The flag is defaulted to false to keep legacy behavior.

### Platforms Affected ### 
Tested on WPF.

### Behavioral Changes ###
None, Care was taken to make this change 100% backwards compatible.  If the feature is enabled it allows for side navigation pane to auto size the space between the wizard page ellipses.

### Testing Procedure ###

Updating the ExampleSideNavigationWizard.cs constructor will exercise the new logic:
            MinSize = new System.Windows.Size(800, 600);
            MaxSize = new System.Windows.Size(1000, 600);
            AutoSizeSideNavigationPane = true;

### PR Checklist ###

- [Yes] I have included examples or tests
- [No ] I have updated the change log
- [No] I am listed in the CONTRIBUTORS file
- [Yes] Rebased on top of the target branch at time of PR
- [ ?] Changes adhere to coding standard
